### PR TITLE
[prevent_spoiler_query] Reduce amount of database checks due to spoiler

### DIFF
--- a/src/command/commands/social/Spoiler.js
+++ b/src/command/commands/social/Spoiler.js
@@ -25,7 +25,12 @@ class Spoiler extends Command {
       const user = this.client.users.get(event.d.user_id);
       if (user.bot) return;
 
+      const channel   = this.client.channels.get(event.d.channel_id);
       const messageId = event.d.message_id;
+      const message   = await channel.fetchMessage(messageId);
+      const author    = message.author;
+      if (!author.bot) return
+
       const spoiler = await this.spoilerProvider.get(messageId);
       if (!spoiler || !spoiler.text.length)
         return


### PR DESCRIPTION
Previously, any non-bot reactions were causing a db query.
Now, only reactions to messages created by bots are scanned.

Further optimisations could query message contents for a certain string
before checking. Also, check that message came from that particular bot
id, not any bot.